### PR TITLE
Use netstandard rather than core as target

### DIFF
--- a/FinancialFormulas/FinancialFormulas.csproj
+++ b/FinancialFormulas/FinancialFormulas.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright></Copyright>
     <PackageLicenseUrl>https://github.com/srbrettle/Financial-Formulas-Library-.NET-Core/blob/master/LICENSE</PackageLicenseUrl>
@@ -12,7 +12,7 @@
     <Description>A collection of methods for solving Finance/Accounting equations.</Description>
     <PackageTags>financial, formulas, equations, calculations, finance, accounting, economics, invest, math, mathematics, business, entrepreneur, banking</PackageTags>
     <RepositoryUrl>https://github.com/srbrettle/Financial-Formulas-Library-.NET-Core</RepositoryUrl>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PackageIconUrl>https://raw.githubusercontent.com/srbrettle/Financial-Formulas-Library-.NET-Core/master/FinancialFormulas.png</PackageIconUrl>
   </PropertyGroup>


### PR DESCRIPTION
Use netstandard rather than core as the library has no dependencies beyond itself and this will make it compatible with anything that can use standard (full framework 4.6+)